### PR TITLE
CRAB-42491: Remove unnecessary mention of Features/Plugins/Enabled from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,10 +108,6 @@ When you are ready to deploy your connector to a test or production remote agent
 created in the `build/distributions` folder of your connector.
 
 1. Shut down the Seeq Remote Agent - execute `seeq stop` in the Seeq CLI
-1. Verify that you have enabled support for plugins
-   1. execute `seeq config get Features/Plugins/Enabled` in the Seeq CLI
-   1. Ensure the value is `True`
-   1. If it is not then execute `seeq config set Features/Plugins/Enabled True`
 1. Copy the generated zip file to the `plugins/connectors` folder within Seeq's `data` folder (The data folder 
    is usually `C:\ProgramData\Seeq\data`)
 1. Extract the contents of the zip file.


### PR DESCRIPTION
As [pointed out](https://github.com/seeq12/seeq-connector-sdk-java/pull/3#discussion_r1674377585) by @mar1u50, enabling "Features/Plugins/Enabled" turns out to be unnecessary (I tested on jvm-link and was able to deploy the connector with the config option disabled).

My bad for missing this on my review!

Primary reviewer: @cherrera2001 
Knowledge base: N/A
Compatibility breaks: N/A
Security considerations pursuant to our SAMM model: N/A
Exploratory functional testing: N/A
Regression testing Tests were updated: N/A
Product Owner acceptance: @cherrera2001
Presentation slide: N/A