### PR TITLE
Change Seeq debugger `searchPath` to allow for connection builds with dependencies

### DIFF
--- a/seeq-link-sdk-debugging-agent/src/main/java/com/seeq/link/sdk/debugging/Main.java
+++ b/seeq-link-sdk-debugging-agent/src/main/java/com/seeq/link/sdk/debugging/Main.java
@@ -54,7 +54,7 @@ public class Main {
         }
 
         Path connectorSdkRoot = executingAssemblyLocation.getParent().getParent().getParent().getParent().getParent();
-        String searchPath = connectorSdkRoot.toString() + "/*connector*/build/libs/*connector*.jar";
+        String searchPath = connectorSdkRoot.toString() + "/*connector*/build/install/*connector*/*connector*.jar";
 
         config.setConnectorSearchPaths(searchPath);
 


### PR DESCRIPTION
Using the default `searchPath` is ok when your connector doesn't have any implementation dependencies but when it does they are not included and your connector fails to load due to classes not found. By changing this to the install path, all the dependences are available and you are able to debug you connector with dependencies.