### PR TITLE
CRAB-46033: Use CapsuleIdProperty in java-connector-sdk-example

### DIFF
--- a/mycompany-seeq-link-connector-myconnector/src/main/java/com/mycompany/seeq/link/connector/DatasourceSimulator.java
+++ b/mycompany-seeq-link-connector-myconnector/src/main/java/com/mycompany/seeq/link/connector/DatasourceSimulator.java
@@ -97,7 +97,7 @@ public class DatasourceSimulator {
                 )
                 .mapToObj(index -> {
                     ZonedDateTime start = new TimeInstant(index * capsulePeriodInNanos).toDateTime();
-                    ZonedDateTime end = ChronoUnit.MILLIS.addTo(start, 10L);
+                    ZonedDateTime end = ChronoUnit.MILLIS.addTo(start, 10000L);
                     return new Alarm.Event(start, end, RNG.nextDouble());
                 })
                 .limit(limit);


### PR DESCRIPTION
Updated the example connector to use CapsuleIdProperty to specify the capsule property that give the id of the capsule.

Primary: @DJamesP 

csharp version: https://github.com/seeq12/seeq-connector-sdk-csharp/pull/16